### PR TITLE
Body type search

### DIFF
--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -160,6 +160,7 @@ export interface SearchData {
     furryprefs: string[]
     roles: string[]
     positions: string[]
+    bodytypes: string[]
 }
 
 export interface ExtendedSearchData extends SearchData {

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -231,6 +231,7 @@ Once this process has started, do not interrupt it or your logs will get corrupt
     'characterSearch.roles': 'Dom/sub roles',
     'characterSearch.positions': 'Positions',
     'characterSearch.species': 'Species (beta)',
+    'characterSearch.bodytypes': 'Body Types',
     'characterSearch.error.noResults': 'There were no search results.',
     'characterSearch.error.throttle': 'You must wait five seconds between searches.',
     'characterSearch.error.tooManyResults': 'There are too many search results, please narrow your search.',


### PR DESCRIPTION
Fixes #42 

Usage: First search without body type, and then add body type. I think this is because of cache because body type search rejects anything not cached? I did that because I don't want false positives in the search results.

It's a real shame the backend server does not seem to support this directly, because in my limited testing, doing only feral search results does like a 20x reduction of the search results.