### PR TITLE
Fix insane bug where some profiles cause client hang

### DIFF
--- a/chat/preview/CharacterPreview.vue
+++ b/chat/preview/CharacterPreview.vue
@@ -213,7 +213,7 @@ export default class CharacterPreview extends Vue {
   updateCustoms(): void {
     this.customs = _.orderBy(
       _.map(
-        _.reject(this.character!.character.customs || [], (c) => _.isUndefined(c)) as CustomKink[],
+        _.reject(Object.values(this.character!.character.customs ?? []), (c) => _.isUndefined(c)) as CustomKink[],
         (c: CustomKink) => _.assign(
           {},
           c,

--- a/learn/store/worker.ts
+++ b/learn/store/worker.ts
@@ -26,7 +26,22 @@ export class WorkerStore implements PermanentIndexedStore {
 
 
     async getProfile(name: string): Promise<ProfileRecord | undefined> {
-        return this.workerClient.request('get', { name });
+        const record: ProfileRecord | undefined = await this.workerClient.request('get', { name });
+
+        // fix custom kinks to prevent hangs
+
+        if (record && Array.isArray(record.profileData.character.customs)) {
+            // fix customs because it will crash the client
+            const customsObject: ProfileRecord['profileData']['character']['customs'] = {};
+
+            for (const [key, value] of Object.entries(record.profileData.character.customs)) {
+                if (value !== undefined) customsObject[key] = value;
+            }
+
+            record.profileData.character.customs = customsObject;
+        }
+
+        return record;
     }
 
 


### PR DESCRIPTION
Some code was converting the customs object to an array with millions of elements, which caused iteration and ipc transport (json serialize) to hang the client for many minutes at a time.

This is probably because incorrect lodash functions were used on the customs. Lodash would convert it to array and then it would get stored and turn up as array every time, corrupting storage and ensuring client denial of service.

This fixes that bug by avoiding using incorrect lodash functions that convert things to arrays with millions of elements.

It also retroactively fixes profiles that were stored with array customs, so the client won't crash.