### PR TITLE
Removes seemingly superfluous arrow in galleries

### DIFF
--- a/site/character_page/images.vue
+++ b/site/character_page/images.vue
@@ -3,9 +3,6 @@
     <div class="character-images">
         <div v-show="((loading) && (images.length === 0))" class="alert alert-info">Loading images.</div>
         <template v-if="!loading">
-            <div class="images-navigate-up">
-                <i class="fa fa-angle-up"></i>
-            </div>
 
             <!-- @click="handleImageClick($event, image)" -->
             <div v-for="image in images" :key="image.id" class="character-image-wrapper">


### PR DESCRIPTION
This arrow was added in the original repository around 4 years ago and, as far as I could test, all it does is slightly irk me any time I open a profile and notice that the top two images are misaligned. I couldn't really find any functionality behind it in the code.
That's assuming this isn't some kind of load-bearing icon that keeps the entire profile viewer afloat somehow, in which case you're free to beat me over the head with a rusty socket wrench.