### PR TITLE
Remove animation from new conversation/channel buttons

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -65,7 +65,7 @@
                     </div>
                 </a>
 
-                <a href="#" @click.prevent="showAddPmPartner()" class="new-conversation" :class="{ glowing: conversations.privateConversations.length === 0 }">Open Conversation</a>
+                <a href="#" @click.prevent="showAddPmPartner()" class="new-conversation">Open Conversation</a>
             </div>
 
             <a href="#" @click.prevent="showChannels()" class="btn"><span class="fas fa-list"></span>
@@ -86,7 +86,7 @@
                     </span>
                 </a>
 
-                <a href="#" @click.prevent="showChannels()" class="join-channel" :class="{ glowing: conversations.channelConversations.length === 0 }">Join Channel</a>
+                <a href="#" @click.prevent="showChannels()" class="join-channel">Join Channel</a>
             </div>
         </sidebar>
         <div style="display:flex;flex-direction:column;flex:1;min-width:0">
@@ -627,32 +627,6 @@
           font-size: 90%;
           margin-left: 0.2em;
           margin-top: 0.25em;
-        }
-
-        .glowing {
-          padding: 3px;
-          margin-right: 0.5em;
-          animation: noticeme 2.5s infinite alternate;
-          animation-timing-function: ease-in-out;
-        }
-
-        .join-channel.glowing {
-          animation-delay: 0.3s !important;
-        }
-
-        @keyframes noticeme {
-          0% {
-            // box-shadow: 0 0 10px -10px #aef4af;
-            color: var(--gray-dark)
-          }
-          80% {
-            // box-shadow: 0 0 10px -10px #aef4af;
-            color: var(--gray-dark)
-          }
-          100% {
-            // box-shadow: 0 0 10px 10px #aef4af;
-            color: var(--yellow)
-          }
         }
     }
 </style>


### PR DESCRIPTION
I'm not even sure why they're here, seeing as the headers do the exact same thing, but they're very distracting if you intend on only using PMs/channels and not the other. I don't see why they have to blink forever.