### PR TITLE
Use alternative frontend for YT (No more ads)

### DIFF
--- a/chat/preview/image-dom-mutator.ts
+++ b/chat/preview/image-dom-mutator.ts
@@ -140,6 +140,7 @@ export class ImageDomMutator {
         /* tslint:disable max-line-length */
         this.add('default', this.getBaseJsMutatorScript(['.content video', '.content img', '#video, video', '#image, img']));
         this.add('about:blank', '');
+        this.add('yewtu.be', '');
         this.add('e621.net', this.getBaseJsMutatorScript(['video', '#image']));
         this.add('e-hentai.org', this.getBaseJsMutatorScript(['video', '#img']));
         this.add('gelbooru.com', this.getBaseJsMutatorScript(['video.gelcomVPlayer', '.post-view video', '.contain-push video', '#image']));

--- a/chat/preview/image-url-mutator.ts
+++ b/chat/preview/image-url-mutator.ts
@@ -34,6 +34,13 @@ export class ImageUrlMutator {
 
     protected init(): void {
         this.add(
+            /^http(?:s?):\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-\_]*)(&(amp;)?[\w\?=]*)?/,
+            async(_url: string, match: RegExpMatchArray): Promise<string> => {
+                const videoId = match[1]
+                return `https://yewtu.be/embed/${videoId}?autoplay=1`
+            }
+        );
+        this.add(
            /^https?:\/\/.*twitter.com\/(.*)/,
            async(url: string, match: RegExpMatchArray): Promise<string> => {
                 const path = match[1];


### PR DESCRIPTION
Pros:
- Preview for YT works perfectly now. 
- You never have to deal with an ad playing before the video.
- Seriously, you just hover over the video and it starts playing. Compare and contrast to the current experience.

Cons:
- Similarly to the Twitter patch, this relies on an external frontend hosted by someone else. However, unlike the Twitter patch, there is no fallback if the request fails. 
There's [a list of frontends you can use](https://redirect.invidious.io/), and I picked the one that I found to be most reliable. In case this one fails, it can be simply swapped out.
- For some reason, despite the blank dom mutator, the `default` one takes hold. Bumping it as far up the list as possible seems to have mostly mitigated this, though...